### PR TITLE
Changed references from RallyVersioningPlugin to GitVersioningPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ In either case, you should now be able to add the plugin dependency to `project/
   addSbtPlugin("com.rallyhealth.sbt" % "git-versioning-sbt-plugin" % "x.y.z")
 ```
 3. Enable the plugin and set `semVerLimit` in `build.sbt` (see
- [below](https://github.com/rallyhealth/git-versioning-sbt-plugin#semverversionlimit)
+ [below](https://github.com/rallyhealth/git-versioning-sbt-plugin#semverlimit)
  for details)
 
 ```scala
 val example = project
   .enablePlugins(SemVerPlugin)
-  // See https://github.com/rallyhealth/git-versioning-sbt-plugin#semverversionlimit
+  // See https://github.com/rallyhealth/git-versioning-sbt-plugin#semverlimit
   .settings(semVerLimit := "x.y.z")
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ sbtPlugin := true
 name := "git-versioning-sbt-plugin"
 organizationName := "Rally Health"
 organization := "com.rallyhealth.sbt"
-version := "0.0.1"
+version := "0.0.2"
 licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT"))
 
 bintrayOrganization := Some("rallyhealth")

--- a/src/main/scala/com/rallyhealth/sbt/semver/SemVerPluginUtils.scala
+++ b/src/main/scala/com/rallyhealth/sbt/semver/SemVerPluginUtils.scala
@@ -29,7 +29,7 @@ object SemVerPluginUtils {
     // effectively. It depends on a lot of different SBT settings, and extracting them is a) messy and b) they are
     // often hard to mock
 
-    // "version" SettingKey is assumed to be a SemanticVersion; see the overload in RallyVersioningPlugin
+    // "version" SettingKey is assumed to be a SemanticVersion; see the overload in GitVersioningPlugin
     val semver: SemanticVersion = SemanticVersion.fromString(version.value).getOrElse(
       throw new IllegalArgumentException(s"version=${version.value} is not a valid SemVer"))
     val enforceAfterVersion: Option[ReleaseVersion] = semVerEnforceAfterVersion.value.map(parseAsCleanOrThrow)

--- a/src/main/scala/com/rallyhealth/sbt/versioning/GitVersioningPlugin.scala
+++ b/src/main/scala/com/rallyhealth/sbt/versioning/GitVersioningPlugin.scala
@@ -152,7 +152,7 @@ object GitVersioningPlugin extends AutoPlugin {
       (autoFetchResult in ThisProject).value
       val gitVersion = gitDriver.value.calcCurrentVersion(ignoreDirty.value)
 
-      ConsoleLogger().info(s"RallyVersioningPlugin set versionFromGit=$gitVersion")
+      ConsoleLogger().info(s"GitVersioningPlugin set versionFromGit=$gitVersion")
 
       gitVersion
     },
@@ -167,7 +167,7 @@ object GitVersioningPlugin extends AutoPlugin {
               throw new IllegalArgumentException(msg)
             }
 
-          ConsoleLogger().info(s"RallyVersioningPlugin set versionOverride=$versionOverrideStr")
+          ConsoleLogger().info(s"GitVersioningPlugin set versionOverride=$versionOverrideStr")
           ver.toString
       }
     },
@@ -204,7 +204,7 @@ object GitVersioningPlugin extends AutoPlugin {
       }
 
       val version = verOverride.getOrElse(boundedVersionFromGit).toString
-      ConsoleLogger().info(s"RallyVersioningPlugin set version=$version")
+      ConsoleLogger().info(s"GitVersioningPlugin set version=$version")
       version
     },
 
@@ -214,7 +214,7 @@ object GitVersioningPlugin extends AutoPlugin {
         .getOrElse(throw new IllegalArgumentException(s"cannot parse version=${version.value}"))
         .isDirty
 
-      ConsoleLogger().info(s"RallyVersioningPlugin set isCleanRelease=${!isDirty}")
+      ConsoleLogger().info(s"GitVersioningPlugin set isCleanRelease=${!isDirty}")
 
       !isDirty
     },

--- a/src/sbt-test/semver/multi-project/test
+++ b/src/sbt-test/semver/multi-project/test
@@ -1,4 +1,4 @@
-# Set up a git repo appease RallyVersioningPlugin and tag first version.
+# Set up a git repo appease GitVersioningPlugin and tag first version.
 $ exec git init
 $ exec git add .
 $ exec git commit -am 'Initial commit.'

--- a/src/sbt-test/semver/new-artifact/test
+++ b/src/sbt-test/semver/new-artifact/test
@@ -6,7 +6,7 @@
 # "semVerEnforceAfterVersion".
 ###########################################################################################################
 
-# Set up a git repo appease RallyVersioningPlugin and tag first version.
+# Set up a git repo appease GitVersioningPlugin and tag first version.
 $ exec git init
 $ exec git add .
 $ exec git commit -am 'Initial commit.'

--- a/src/sbt-test/semver/rename-artifact/test
+++ b/src/sbt-test/semver/rename-artifact/test
@@ -3,7 +3,7 @@
 # scenario SemVer can only be bypassed by making a MAJOR version change.
 ###########################################################################################################
 
-# Set up a git repo appease RallyVersioningPlugin and tag first version.
+# Set up a git repo appease GitVersioningPlugin and tag first version.
 $ exec git init
 $ exec git add .
 $ exec git commit -am 'Initial commit.'

--- a/src/sbt-test/semver/tagging/test
+++ b/src/sbt-test/semver/tagging/test
@@ -2,7 +2,7 @@
 # Uses "tag then publish" workflow.
 ###########################################################################################################
 
-# Set up a git repo appease RallyVersioningPlugin and tag first version.
+# Set up a git repo appease GitVersioningPlugin and tag first version.
 $ exec git init
 $ exec git add .
 $ exec git commit -am 'Initial commit.'

--- a/src/sbt-test/versioning/fromGit/test
+++ b/src/sbt-test/versioning/fromGit/test
@@ -1,5 +1,5 @@
 ############################################################################################################
-# Basic sanity tests for RallyVersioningPlugin
+# Basic sanity tests for GitVersioningPlugin
 
 # Init the repo
 $ exec git init

--- a/src/sbt-test/versioning/odd/test
+++ b/src/sbt-test/versioning/odd/test
@@ -1,6 +1,6 @@
 ############################################################################################################
-# Tests for odd behavior for RallyVersioningPlugin. Not necessarily wrong, but definitely less obvious
-# to those who are not intimately familiar with all the dark magic in RallyVersioningPlugin.
+# Tests for odd behavior for GitVersioningPlugin. Not necessarily wrong, but definitely less obvious
+# to those who are not intimately familiar with all the dark magic in GitVersioningPlugin.
 
 # I've tried to call out the "odd" behavior with triple bang "!!!"
 

--- a/src/sbt-test/versioning/tagging/test
+++ b/src/sbt-test/versioning/tagging/test
@@ -1,5 +1,5 @@
 ############################################################################################################
-# Tagging tests for RallyVersioningPlugin, some sane, some pathological
+# Tagging tests for GitVersioningPlugin, some sane, some pathological
 
 # Init the repo
 $ exec git init

--- a/src/test/resources/scriptedOutput-example1.txt
+++ b/src/test/resources/scriptedOutput-example1.txt
@@ -139,9 +139,9 @@ Initialized empty Git repository in /private/var/folders/vp/p4d6nc0d7bnctv6j0lgr
 [0m[[0minfo[0m] [0m[0m[[0minfo[0m] [0mSkipping fetching tags from git remotes; to enable, set the system property version.autoFetch=true[0m[0m
 [0m[[0minfo[0m] [0m[ScriptedUtils] sideChannelFile: /private/var/folders/vp/p4d6nc0d7bnctv6j0lgr3ky40000gp/T/sbt_6c5b0244/sanity/scriptedOutput-1480303571457.link.txt[0m
 [0m[[0minfo[0m] [0m[ScriptedUtils] bufferedFile: /var/folders/vp/p4d6nc0d7bnctv6j0lgr3ky40000gp/T/scriptedOutput-2194719900698081813.log.txt[0m
-[0m[[0minfo[0m] [0m[0m[[0minfo[0m] [0mRallyVersioningPlugin set versionFromGit=0.0.1[0m[0m
-[0m[[0minfo[0m] [0m[0m[[0minfo[0m] [0mRallyVersioningPlugin set version=0.0.1[0m[0m
-[0m[[0minfo[0m] [0m[0m[[0minfo[0m] [0mRallyVersioningPlugin set isCleanRelease=true[0m[0m
+[0m[[0minfo[0m] [0m[0m[[0minfo[0m] [0mGitVersioningPlugin set versionFromGit=0.0.1[0m[0m
+[0m[[0minfo[0m] [0m[0m[[0minfo[0m] [0mGitVersioningPlugin set version=0.0.1[0m[0m
+[0m[[0minfo[0m] [0m[0m[[0minfo[0m] [0mGitVersioningPlugin set isCleanRelease=true[0m[0m
 [0m[[0minfo[0m] [0m[0m[[0minfo[0m] [0mSet current project to sanity (in build file:/private/var/folders/vp/p4d6nc0d7bnctv6j0lgr3ky40000gp/T/sbt_6c5b0244/sanity/)[0m[0m
 [0m[[0minfo[0m] [0m[0m[[0minfo[0m] [0m[ScriptedUtils] Starting load_plugin ----------------------------[0m[0m
 [0m[[0minfo[0m] [0m[0m[[32msuccess[0m] [0mTotal time: 0 s, completed Nov 27, 2016 10:26:22 PM[0m[0m
@@ -152,7 +152,7 @@ Initialized empty Git repository in /private/var/folders/vp/p4d6nc0d7bnctv6j0lgr
 [0m[[0minfo[0m] [0m	sbt.plugins.JUnitXmlReportPlugin: enabled in sanity[0m
 [0m[[0minfo[0m] [0m	sbt.plugins.Giter8TemplatePlugin: enabled in sanity[0m
 [0m[[0minfo[0m] [0m	com.rallyhealth.semver.SemVerPlugin: enabled in sanity[0m
-[0m[[0minfo[0m] [0m	com.rallyhealth.versioning.RallyVersioningPlugin: enabled in sanity[0m
+[0m[[0minfo[0m] [0m	com.rallyhealth.versioning.GitVersioningPlugin: enabled in sanity[0m
 [0m[[0minfo[0m] [0m	com.typesafe.tools.mima.plugin.MimaPlugin: enabled in sanity[0m
 [0m[[0minfo[0m] [0m[0m[[32msuccess[0m] [0mTotal time: 0 s, completed Nov 27, 2016 10:26:22 PM[0m[0m
 [0m[[0minfo[0m] [0m[0m[[32msuccess[0m] [0mTotal time: 0 s, completed Nov 27, 2016 10:26:22 PM[0m[0m


### PR DESCRIPTION
@rallyhealth/engineers @rcmurphy @htmldoug

A quick patch to fix the logging (so it matches the project name / Scala object) when booting up sbt.
Also, bumped the version to 0.0.2. The next version will use git-versioning-sbt-plugin, but the sbt key names changed between 0.0.1 and this version, so I have to release 0.0.2 first before I can depend on it.