### PR TITLE
Add support for setting the length of the snapshot abbreviation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ This is useful for preparing major releases with breaking changes (esp. when com
 | 1.0.0-n-0123abc-SNAPSHOT |                                   | 1.0.0-n-0123abc-SNAPSHOT |
 | 1.0.0                    | 2.0.0                             | 2.0.0-n-0123abc-SNAPSHOT |
 
+### abbrevLength
+
+The `abbrevLength` settingKey can be used to manually force a certain length used for the hash in the version description. This is normally set by Git, which sets a minimum length based on the number of commits in your repository (with a minimum of 7). Setting this number manually can be useful if your CI server is working with shallow repositories (which is not recommended - see "Notes") or you want to ensure a consistent length of snapshot versions as your repository grows. This parameter matches the behavior of the `--abbrev` parameter of `git describe`.
+
 ### Release arg Property
 
 The release arg bumps the version up by a major, minor, or patch increment.
@@ -146,9 +150,9 @@ since the creation of the repository.
 * This plugin is intentionally different than something like [sbt-release](https://github.com/sbt/sbt-release) which stores
 the version in a `version.sbt` file. Those types of plugins require more manual effort on the part of the developer.
 
-*Warning:* Git Versioning may misbehave with shallow clones. If the incorrect version is being returned and tags are
+*Warning:* Git Versioning may misbehave with shallow clones, as it cannot be guaranteed that a shallow clone includes all tags and commits necessary to determine the version in a consistent If the incorrect version is being returned and tags are
 accessible, you may be using a shallow clone, in which case `git fetch --unshallow` will fix the issue. On CI systems,
-ensure that any git plugins are configured to not use shallow clones.
+ensure that any git plugins are configured to not use shallow clones. If you are unable to use deep clones, you can set the `abbrevLength` parameter in order to ensure snapshot versions are consistently named.
 
 ## Creating a Release
 

--- a/src/main/scala/com/rallyhealth/sbt/semver/SemVerTasks.scala
+++ b/src/main/scala/com/rallyhealth/sbt/semver/SemVerTasks.scala
@@ -16,7 +16,7 @@ object SemVerTasks {
     val typePrefix = s"$SemVerPrefix Check type:"
     val abortPrefix = s"$SemVerPrefix Check aborted:"
 
-    git.branchState match {
+    git.branchState(7) match {
       case GitBranchStateTwoReleases(_, headVersion, _, prevVersion) =>
         if (git.workingState.isDirty) {
           logger.debug(s"$typePrefix comparing most recent release with post-tag changes")

--- a/src/main/scala/com/rallyhealth/sbt/versioning/SemVerIdentifier.scala
+++ b/src/main/scala/com/rallyhealth/sbt/versioning/SemVerIdentifier.scala
@@ -104,7 +104,7 @@ case class HashSemVerIdentifier(hash: String) extends SemVerIdentifier {
 
 object HashSemVerIdentifier {
 
-  val regex: Regex = "g?[0-9a-f]{7,}".r
+  val regex: Regex = "g?[0-9a-f]+".r
 
   /**
     * If necessary removes the pre-pended 'g' to match [[GitVersioningPlugin]] format.

--- a/src/test/scala/com/rallyhealth/sbt/versioning/GitDriverImplSpec.scala
+++ b/src/test/scala/com/rallyhealth/sbt/versioning/GitDriverImplSpec.scala
@@ -399,6 +399,36 @@ class GitDriverImplSpec extends FunSpec {
       }
     }
   }
+
+  describe("branchState") {
+    val tempDir = new File(System.getProperty("java.io.tmpdir"))
+    val fakeGitRepo = "testing_temp_git_repo_" + Random.nextInt(1000000000)
+    Process(s"""git init $fakeGitRepo""".trim, tempDir).!!
+    val newWorkingDir = new File(System.getProperty("java.io.tmpdir"), fakeGitRepo)
+    val fileName = "testing_only_should_be_deleted"
+    val tempFile = new File(newWorkingDir, fileName)
+    assert(tempFile.createNewFile())
+    Process(s"""git add $fileName""".trim, newWorkingDir).!!
+    Process(s"""git commit -m 'Empty'""".trim, newWorkingDir).!!
+
+    val driver = new GitDriverImpl(newWorkingDir)
+    
+    it("abbrevLength 4") {
+      val version = driver.calcCurrentVersion(ignoreDirty = false, abbrevLength = 4)
+      assert(version.toString.length == "0.0.1-1-abcd-SNAPSHOT".length)
+    }
+
+    it("abbrevLength 7") {
+      val version = driver.calcCurrentVersion(ignoreDirty = false, abbrevLength = 7)
+      assert(version.toString.length == "0.0.1-1-abcdefg-SNAPSHOT".length)
+    }
+
+    it("abbrevLength 40") {
+      val version = driver.calcCurrentVersion(ignoreDirty = false, abbrevLength = 40)
+      assert(version.toString.length == "0.0.1-1-abcdefghijklmnopqrstuvxyz123456789123456-SNAPSHOT".length)
+    }    
+
+  }
 }
 
 object GitDriverImplSpec {

--- a/src/test/scala/com/rallyhealth/sbt/versioning/GitDriverImplSpec.scala
+++ b/src/test/scala/com/rallyhealth/sbt/versioning/GitDriverImplSpec.scala
@@ -31,7 +31,7 @@ class GitDriverImplSpec extends FunSpec {
     it("branchState") {
       // did it do something? I don't care what it did really, as long as it didn't throw
       val driver = new GitDriverImpl(workingDir)
-      val branchState = driver.branchState
+      val branchState = driver.branchState(7)
       // I need to do something or the compiler could eliminate the call
       assert(branchState === branchState)
     }
@@ -120,7 +120,7 @@ class GitDriverImplSpec extends FunSpec {
           val branchState = GitBranchStateNoCommits
           val workingState = GitWorkingState(isDirty = true)
           val gitDriver = MockDriver(branchState, workingState)
-          val result = gitDriver.calcCurrentVersion(ignoreDirty = false)
+          val result = gitDriver.calcCurrentVersion(ignoreDirty = false, abbrevLength = 7)
           assert(result.toString === "0.0.1-dirty-SNAPSHOT") // check against the README.md
           assert(result === ReleaseVersion.initialVersion.copy(isDirty = true))
         }
@@ -129,7 +129,7 @@ class GitDriverImplSpec extends FunSpec {
           val branchState = GitBranchStateNoCommits
           val workingState = GitWorkingState(isDirty = false)
           val gitDriver = MockDriver(branchState, workingState)
-          val result = gitDriver.calcCurrentVersion(ignoreDirty = false)
+          val result = gitDriver.calcCurrentVersion(ignoreDirty = false, abbrevLength = 7)
           assert(result.toString === "0.0.1") // check against the README.md
           assert(result === ReleaseVersion.initialVersion)
         }
@@ -147,7 +147,7 @@ class GitDriverImplSpec extends FunSpec {
           val branchState = GitBranchStateNoReleases(GitCommitWithCount(GitCommit(gitHash, 7, Seq.empty), 1))
           val workingState = GitWorkingState(isDirty = true)
           val gitDriver = MockDriver(branchState, workingState)
-          val result = gitDriver.calcCurrentVersion(ignoreDirty = false)
+          val result = gitDriver.calcCurrentVersion(ignoreDirty = false, abbrevLength = 7)
           assert(result.toString === "0.0.1-1-0123abc-dirty-SNAPSHOT") // check against the README.md
           assert(result === SnapshotVersion(0, 0, 1, SemVerIdentifierList.empty, isDirty = true, gitHash.take(7), 1))
         }
@@ -156,7 +156,7 @@ class GitDriverImplSpec extends FunSpec {
           val branchState = GitBranchStateNoReleases(GitCommitWithCount(GitCommit(gitHash, 7, Seq.empty), 1))
           val workingState = GitWorkingState(isDirty = false)
           val gitDriver = MockDriver(branchState, workingState)
-          val result = gitDriver.calcCurrentVersion(ignoreDirty = false)
+          val result = gitDriver.calcCurrentVersion(ignoreDirty = false, abbrevLength = 7)
           assert(result.toString === "0.0.1-1-0123abc-SNAPSHOT") // check against the README.md
           assert(result === SnapshotVersion(0, 0, 1, SemVerIdentifierList.empty, isDirty = false, gitHash.take(7), 1))
         }
@@ -183,7 +183,7 @@ class GitDriverImplSpec extends FunSpec {
           val branchState = GitBranchStateOneReleaseHead(GitCommit(gitHash, 7, Seq("1.1.0")), prevRelease)
           val workingState = GitWorkingState(isDirty = false)
           val gitDriver = MockDriver(branchState, workingState)
-          val result = gitDriver.calcCurrentVersion(ignoreDirty = false)
+          val result = gitDriver.calcCurrentVersion(ignoreDirty = false, abbrevLength = 7)
           assert(result.toString === "1.1.0") // check against the README.md
           assert(result === prevRelease)
         }
@@ -243,7 +243,7 @@ class GitDriverImplSpec extends FunSpec {
             prevRelease)
           val workingState = GitWorkingState(isDirty = true)
           val gitDriver = MockDriver(branchState, workingState)
-          val result = gitDriver.calcCurrentVersion(ignoreDirty = false)
+          val result = gitDriver.calcCurrentVersion(ignoreDirty = false, abbrevLength = 7)
           assert(result.toString === "1.0.4-1-0123abc-dirty-SNAPSHOT") // check against the README.md
           assert(result === SnapshotVersion(1, 0, 4, SemVerIdentifierList.empty, isDirty = true, gitHash.take(7), 1))
         }
@@ -256,7 +256,7 @@ class GitDriverImplSpec extends FunSpec {
             prevRelease)
           val workingState = GitWorkingState(isDirty = false)
           val gitDriver = MockDriver(branchState, workingState)
-          val result = gitDriver.calcCurrentVersion(ignoreDirty = false)
+          val result = gitDriver.calcCurrentVersion(ignoreDirty = false, abbrevLength = 7)
           assert(result.toString === "1.0.4-1-0123abc-SNAPSHOT") // check against the README.md
           assert(result === SnapshotVersion(1, 0, 4, SemVerIdentifierList.empty, isDirty = false, gitHash.take(7), 1))
         }
@@ -331,7 +331,7 @@ class GitDriverImplSpec extends FunSpec {
           val branchState = GitBranchStateTwoReleases(headCommit, prevCommit)
           val workingState = GitWorkingState(isDirty = true)
           val gitDriver = MockDriver(branchState, workingState)
-          val result = gitDriver.calcCurrentVersion(ignoreDirty = false)
+          val result = gitDriver.calcCurrentVersion(ignoreDirty = false, abbrevLength = 7)
           assert(result.toString === "1.1.0-dirty-SNAPSHOT") // check against the README.md
           assert(result === ReleaseVersion(1, 1, 0, SemVerIdentifierList.empty, isDirty = true))
         }
@@ -342,7 +342,7 @@ class GitDriverImplSpec extends FunSpec {
           val branchState = GitBranchStateTwoReleases(headCommit, prevCommit)
           val workingState = GitWorkingState(isDirty = false)
           val gitDriver = MockDriver(branchState, workingState)
-          val result = gitDriver.calcCurrentVersion(ignoreDirty = false)
+          val result = gitDriver.calcCurrentVersion(ignoreDirty = false, abbrevLength = 7)
           assert(result.toString === "1.1.0") // check against the README.md
           assert(result === ReleaseVersion(1, 1, 0, SemVerIdentifierList.empty, isDirty = false))
         }
@@ -355,7 +355,7 @@ class GitDriverImplSpec extends FunSpec {
         val branchState = GitBranchStateNoCommits
         val workingState = GitWorkingState(isDirty = true)
         val gitDriver = MockDriver(branchState, workingState)
-        val result = gitDriver.calcCurrentVersion(ignoreDirty = true)
+        val result = gitDriver.calcCurrentVersion(ignoreDirty = true, abbrevLength = 7)
         assert(result.toString === "0.0.1")
         assert(result === ReleaseVersion.initialVersion)
       }
@@ -364,7 +364,7 @@ class GitDriverImplSpec extends FunSpec {
         val branchState = GitBranchStateNoReleases(GitCommitWithCount(GitCommit(gitHash, 7, Seq.empty), 1))
         val workingState = GitWorkingState(isDirty = true)
         val gitDriver = MockDriver(branchState, workingState)
-        val result = gitDriver.calcCurrentVersion(ignoreDirty = true)
+        val result = gitDriver.calcCurrentVersion(ignoreDirty = true, abbrevLength = 7)
         assert(result.toString === "0.0.1-1-0123abc-SNAPSHOT")
         assert(result === SnapshotVersion(0, 0, 1, SemVerIdentifierList.empty, isDirty = false, gitHash.take(7), 1))
       }
@@ -373,7 +373,7 @@ class GitDriverImplSpec extends FunSpec {
         val branchState = GitBranchStateOneReleaseHead(GitCommit(gitHash, 7, Seq("1.0.0")))
         val workingState = GitWorkingState(isDirty = true)
         val gitDriver = MockDriver(branchState, workingState)
-        val result = gitDriver.calcCurrentVersion(ignoreDirty = true)
+        val result = gitDriver.calcCurrentVersion(ignoreDirty = true, abbrevLength = 7)
         assert(result.toString === "1.0.0")
         assert(result === ReleaseVersion(1, 0, 0, SemVerIdentifierList.empty, isDirty = false))
       }
@@ -383,7 +383,7 @@ class GitDriverImplSpec extends FunSpec {
           GitCommitWithCount(GitCommit(gitHash, 7, Seq.empty), 1), GitCommit(gitHashAlt, 7, Seq("1.0.0")))
         val workingState = GitWorkingState(isDirty = true)
         val gitDriver = MockDriver(branchState, workingState)
-        val result = gitDriver.calcCurrentVersion(ignoreDirty = true)
+        val result = gitDriver.calcCurrentVersion(ignoreDirty = true, abbrevLength = 7)
         assert(result.toString === "1.0.1-1-0123abc-SNAPSHOT")
         assert(result === SnapshotVersion(1, 0, 1, SemVerIdentifierList.empty, isDirty = false, gitHash.take(7), 1))
       }
@@ -393,7 +393,7 @@ class GitDriverImplSpec extends FunSpec {
           GitCommit(gitHash, 7, Seq("2.0.0")), GitCommit(gitHashAlt, 7, Seq("1.0.0")))
         val workingState = GitWorkingState(isDirty = true)
         val gitDriver = MockDriver(branchState, workingState)
-        val result = gitDriver.calcCurrentVersion(ignoreDirty = true)
+        val result = gitDriver.calcCurrentVersion(ignoreDirty = true, abbrevLength = 7)
         assert(result.toString === "2.0.0")
         assert(result === ReleaseVersion(2, 0, 0, SemVerIdentifierList.empty, isDirty = false))
       }
@@ -403,7 +403,9 @@ class GitDriverImplSpec extends FunSpec {
 
 object GitDriverImplSpec {
 
-  case class MockDriver(branchState: GitBranchState, workingState: GitWorkingState) extends GitDriver {
+  case class MockDriver(branchStateMock: GitBranchState, workingState: GitWorkingState) extends GitDriver {
+
+    override def branchState(abbrevLength: Int) = branchStateMock
 
     override def getCommitCount(hash: Option[String]): Int = throw new UnsupportedOperationException
   }

--- a/src/test/scala/com/rallyhealth/sbt/versioning/HashSemVerIdentifierSpec.scala
+++ b/src/test/scala/com/rallyhealth/sbt/versioning/HashSemVerIdentifierSpec.scala
@@ -38,16 +38,6 @@ class HashSemVerIdentifierSpec extends FunSpec {
 
   describe("hash length") {
 
-    it("less than 7") {
-      val random = new Random
-      (0 until 7).foreach { len =>
-        val hash = Iterator.continually(random.nextInt(10)).take(len).map(_.toString).mkString("")
-        intercept[IllegalArgumentException] {
-          HashSemVerIdentifier(hash)
-        }
-      }
-    }
-
     it("more than 40") {
       val random = new Random
       (41 until 50).foreach { len =>


### PR DESCRIPTION
Here is a patch for adding a configuration for setting the abbreviation length of commits via config. I am very open to changing the naming of it, or how it was implemented, because it ended up being a bit more invasive than I had hoped when I started working on it.

I realize the plugin does not recommend using shallow clones, but unshallowing can be quite costly if you have a larger repository. AFAICT there are two main reasons for why unshallowing is problematic for the plugin:
1. A shallow clone only contains the last 50 commits of the master branch. If the last version tag is not among those commits, the behavior will be incorrect. This patch does not address that problem, but in many repositories releases will be frequent enough that this is not a problem in practice.
2. Once you go over a certain amount of commits, `git rev-parse --short` will start returning a commit abbreviation which is longer than 7. In practice, this means `git rev-parse --short` will return different things in a shallow and a deep repository, which means you will start seeing different revisions locally and on your build severs.

This configuration option enables you to address (2).